### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Library (KEYWORD1)
 #######################################
 
-WiFiESP		KEYWORD1	WiFiESP
+WiFiESP	KEYWORD1	WiFiESP
 WiFiESPUdp	KEYWORD1	WiFiESPUDPConstructor
 
 #######################################
@@ -38,14 +38,14 @@ localIP	KEYWORD2
 subnetMask	KEYWORD2
 gatewayIP	KEYWORD2
 SSID	KEYWORD2
-BSSID		KEYWORD2
+BSSID	KEYWORD2
 RSSI	KEYWORD2
 encryptionType	KEYWORD2
 getResult	KEYWORD2
 getSocket	KEYWORD2
 WiFiESPClient	KEYWORD2	WiFiESPClient
 WiFiESPServer	KEYWORD2	WiFiESPServer
-WiFiESPUDP		KEYWORD2	WiFiESPUDPConstructor
+WiFiESPUDP	KEYWORD2	WiFiESPUDPConstructor
 beginPacket	KEYWORD2
 endPacket	KEYWORD2
 parsePacket	KEYWORD2


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords